### PR TITLE
Fix login redirect loop behind Render reverse proxy

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ const generateAttendancePDF = require('./generate-attendance');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+app.set('trust proxy', 1);
 app.use(helmet());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(express.static('public'));


### PR DESCRIPTION
## Summary
- Adds `app.set('trust proxy', 1)` so Express reads the `X-Forwarded-Proto: https` header from Render's proxy
- Without this, `req.secure` is always `false` internally (Render forwards HTTP internally after SSL termination), so `express-session` never sets the secure session cookie — login appears to succeed but the session is silently dropped and the user lands back on the login page

## Test plan
- [ ] Deploy to Render and verify logging in with valid credentials redirects to `/dashboard` and stays there
- [ ] Check browser DevTools (Application → Cookies) to confirm `connect.sid` cookie is present after login
- [ ] Verify that accessing `/dashboard` without a session still redirects to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)